### PR TITLE
Adding Password Authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - echo "RUN ls -la" > ./Efs2file
 script:
   # Check format and code cleanliness
-  - gofmt -l ./
+  - gofmt -l ./ | grep -v vendor | wc -l | grep -q 0
   - go vet -v
   # Run Tests
   - make tests clean

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ tests:
 	@echo "Launching Tests in Docker Compose"
 	mkdir -p ./testdata
 	test -f ./testdata/testkey || ssh-keygen -b 2048 -t rsa -f ./testdata/testkey -q -N ""
+	test -f ./testdata/wrongkey || ssh-keygen -b 2048 -t rsa -f ./testdata/wrongkey -q -N ""
+	test -f ./testdata/invalidkey || ssh-keygen -b 2048 -t rsa -f ./testdata/invalidkey -q -N "" && sed '5d' ./testdata/invalidkey > ./testdata/tmp.key && mv ./testdata/tmp.key ./testdata/invalidkey
 	test -f ./testdata/testkey-passphrase || ssh-keygen -b 2048 -t rsa -m PEM -f ./testdata/testkey-passphrase -q -N "testing"
 	docker-compose -f dev-compose.yml up --build tests
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Add your examples above!
 ## TODO
 
 * Recursive Directory support for `PUT`
-* Password Authentication support
 * Packaging for brew
 * Templating for uploads
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,8 +11,8 @@ import (
 func TestEfs2(t *testing.T) {
 
 	cfg := config.Config{}
-  cfg.Quiet = true
-  cfg.Verbose = true
+	cfg.Quiet = true
+	cfg.Verbose = true
 	cfg.KeyFile = "/go/src/github.com/madflojo/efs2/testdata/testkey"
 	cfg.User = "test"
 	cfg.Hosts = []string{"openssh-server:2222"}
@@ -34,6 +34,28 @@ func TestEfs2(t *testing.T) {
 		}
 	})
 
+	t.Run("Simple Efs2file with Password", func(t *testing.T) {
+		f, _ := ioutil.TempFile("/tmp/", "testing.*.txt")
+		b := []byte("RUN ls -la\nRUN CMD ls -la\nPUT " + f.Name() + " /tmp/somefile 0644")
+		defer os.Remove(f.Name())
+		_, err := f.Write(b)
+		if err != nil {
+			t.Errorf("Error when creating test file - %s", err)
+		}
+		_ = f.Close()
+		cfg.Efs2File = f.Name()
+		cfg.Quiet = false
+		cfg2 := cfg
+		cfg2.KeyFile = ""
+		cfg2.Password = "testing"
+
+		err = Run(cfg2)
+		if err != nil {
+			t.Errorf("Unexpected Error from App Execution - %s", err)
+		}
+	})
+	cfg.Password = ""
+
 	t.Run("Simple Dryrun Efs2file", func(t *testing.T) {
 		f, _ := ioutil.TempFile("/tmp/", "testing.*.txt")
 		b := []byte("RUN ls -la\nRUN CMD ls -la\nPUT " + f.Name() + " /tmp/somefile 0644")
@@ -45,7 +67,7 @@ func TestEfs2(t *testing.T) {
 		_ = f.Close()
 		cfg.Efs2File = f.Name()
 		cfg.DryRun = true
-    cfg.Quiet = false
+		cfg.Quiet = false
 
 		err = Run(cfg)
 		if err != nil {
@@ -122,7 +144,7 @@ func TestEfs2(t *testing.T) {
 		}
 	})
 
-	t.Run("No Keyfile", func(t *testing.T) {
+	t.Run("No Keyfile No Password", func(t *testing.T) {
 		b := []byte("RUN ls -la\nRUN CMD ls -la")
 		f, _ := ioutil.TempFile("/tmp/", "testing.*.txt")
 		defer os.Remove(f.Name())

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	// Passphrase holds the user-provided SSH key passphrase.
 	Passphrase []byte
 
+	// Password holds the user-provided SSH password.
+	Password string
+
 	// Hosts will contain a list of remote servers to use for execution.
 	Hosts []string
 }

--- a/ssh/ssh.go
+++ b/ssh/ssh.go
@@ -59,6 +59,9 @@ type Config struct {
 
 	// Key provides an SSH key to use for authentication. This key is the private key and requires the public key to be pre-pushed to the remote host for authentication to work.
 	Key ssh.Signer
+
+	// Password provides a password to use for authentication. If the password is present, the Dial function will ignore the SSH Key authentication settings.
+	Password string
 }
 
 // Task is a wrapper structure used during parsing of Efs2 files. Within this structure contains SSH command and file structures.
@@ -104,6 +107,11 @@ func Dial(c Config) (*Conn, error) {
 
 	// Set SSH Key to use
 	cfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(c.Key)}
+
+	// Set Password if set
+	if c.Password != "" {
+		cfg.Auth = []ssh.AuthMethod{ssh.Password(c.Password)}
+	}
 
 	// Open a connection
 	s.client, err = ssh.Dial("tcp", c.Host, cfg)

--- a/ssh/ssh_test.go
+++ b/ssh/ssh_test.go
@@ -43,9 +43,16 @@ func TestReadKeyFile(t *testing.T) {
 			t.Errorf("Unexpected error reading key file - %s", err)
 		}
 	})
+
+	t.Run("Broken Key", func(t *testing.T) {
+		_, err := ReadKeyFile("/go/src/github.com/madflojo/efs2/testdata/invalidkey", []byte(""))
+		if err == nil {
+			t.Errorf("Unexpected success reading key file")
+		}
+	})
 }
 
-func TestBadConnections(t *testing.T) {
+func TestConnections(t *testing.T) {
 	t.Run("Invalid Host", func(t *testing.T) {
 		c, err := ReadKeyFile("/go/src/github.com/madflojo/efs2/testdata/testkey-passphrase", []byte("testing"))
 		if err != nil {
@@ -68,10 +75,40 @@ func TestBadConnections(t *testing.T) {
 
 		_, err = Dial(c)
 		if err == nil {
-			t.Errorf("Unexpected success dialing an invalid host")
+			t.Errorf("Unexpected success dialing without a user")
 		}
 
 	})
+
+	t.Run("Wrong Key", func(t *testing.T) {
+		c, err := ReadKeyFile("/go/src/github.com/madflojo/efs2/testdata/wrongkey", []byte(""))
+		if err != nil {
+			t.Errorf("Unexpected error reading key file - %s", err)
+		}
+		c.Host = "openssh-server:2222"
+		c.User = "test"
+
+		_, err = Dial(c)
+		if err == nil {
+			t.Errorf("Unexpected success dialing a wrong key")
+		}
+	})
+
+	t.Run("Password", func(t *testing.T) {
+		c, err := ReadKeyFile("/go/src/github.com/madflojo/efs2/testdata/wrongkey", []byte(""))
+		if err != nil {
+			t.Errorf("Unexpected error reading key file - %s", err)
+		}
+		c.Host = "openssh-server:2222"
+		c.User = "test"
+		c.Password = "testing"
+
+		_, err = Dial(c)
+		if err != nil {
+			t.Errorf("Unexpected error dialing with a password - %s", err)
+		}
+	})
+
 }
 
 func TestDial(t *testing.T) {


### PR DESCRIPTION
# Description

This pull request adds the ability to use the `--passwd` flag to force Efs2 to ask the user for a password. The password will then be used for authentication to the remote SSH server.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, ensuring GoDoc readability and clarity in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have added tests that ensure my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

If checklist items are unchecked please explain.
